### PR TITLE
live methods has to be changed to on method for jQuery 1.10

### DIFF
--- a/admin-page-class/admin-page-class.php
+++ b/admin-page-class/admin-page-class.php
@@ -1496,12 +1496,12 @@ if ( ! class_exists( 'BF_Admin_Page_Class') ) :
     echo '<script>
         jQuery(document).ready(function() {
           var '.$counter.' = '.$c.';
-          jQuery("#add-'.$jsid.'").live(\'click\', function() {
+          jQuery("#add-'.$jsid.'").on(\'click\', function() {
             '.$counter.' = '.$counter.' + 1;
             jQuery(this).before(\''.$js_code.'\');            
             update_repeater_fields();
           });
-              jQuery("#remove-'.$jsid.'").live(\'click\', function() {
+              jQuery("#remove-'.$jsid.'").on(\'click\', function() {
                   jQuery(this).parent().remove();
               });
           });

--- a/admin-page-class/js/Admin_Page_Class.js
+++ b/admin-page-class/js/Admin_Page_Class.js
@@ -46,7 +46,7 @@ function apc_init(){
   //select 2
   fancySelect();
   // repeater edit
-  $(".at-re-toggle").live('click', function() {$(this).prev().toggle('slow');});
+  $(".at-re-toggle").on('click', function() {$(this).prev().toggle('slow');});
   /**
    * Datepicker Field.
    *
@@ -107,13 +107,13 @@ function apc_init(){
   //new image upload field  
   load_images_muploader();
   //delete img button
-  $('.at-delete_image_button').live('click', function(event){
+  $('.at-delete_image_button').on('click', function(event){
     event.preventDefault();
     remove_image($(this));
     return false;
   });
   //upload images
-  $('.at-upload_image_button').live('click',function(event){
+  $('.at-upload_image_button').on('click',function(event){
     event.preventDefault();
     image_upload($(this));
     return false;
@@ -123,17 +123,17 @@ function apc_init(){
    * @since 0.8
    * @return void
    */
-  $("#apc_import_b").live("click",function(){do_ajax_import_export('import');});
+  $("#apc_import_b").on("click",function(){do_ajax_import_export('import');});
   /**
    * listen for export button click
    * @since 0.8
    * @return void
    */
-  $("#apc_export_b").live("click",function(){do_ajax_import_export('export');});
+  $("#apc_export_b").on("click",function(){do_ajax_import_export('export');});
   //refresh page
-  $("#apc_refresh_page_b").live("click",function(){refresh_page();});
+  $("#apc_refresh_page_b").on("click",function(){refresh_page();});
   //status alert dismiss
-  $('[data-dismiss="alert"]').live("click",function(){$(this).parent().remove()});
+  $('[data-dismiss="alert"]').on("click",function(){$(this).parent().remove()});
 }
 
 /**
@@ -143,11 +143,11 @@ function apc_init(){
  */
 function loadColorPicker(){
   if ($.farbtastic){//since WordPress 3.5
-    $('.at-color').live('focus', function() {
+    $('.at-color').on('focus', function() {
       load_colorPicker($(this).next());
     });
 
-    $('.at-color').live('focusout', function() {
+    $('.at-color').on('focusout', function() {
       hide_colorPicker($(this).next());
     });
 
@@ -156,7 +156,7 @@ function loadColorPicker(){
      *
      * @since 1.0
      */
-    $('.at-color-select').live('click', function(){
+    $('.at-color-select').on('click', function(){
       if ($(this).next('div').css('display') == 'none')
         load_colorPicker($(this));
       else
@@ -228,7 +228,7 @@ function fancyCheckbox(){
     if(! $el.hasClass('no-toggle')){
       $el.FancyCheckbox();
       if ($el.hasClass("conditinal_control")){
-        $el.live('change', function() {
+        $el.on('change', function() {
           var $el = $(this);
           if($el.is(':checked'))
             $el.next().next().show('fast');    
@@ -238,7 +238,7 @@ function fancyCheckbox(){
       }
     }else{
       if ($el.hasClass("conditinal_control")){
-      $el.live('change', function() { 
+      $el.on('change', function() { 
         var $el = $(this);
         if($el.is(':checked'))
           $el.next().show('fast');    


### PR DESCRIPTION
Hello

WordPress 3.6 is using jQuery 1.10. live method for receiving DOM events after the DOM is ready is deprecated since jQuery 1.8. And know, it doesn't work any more in jQuery 1.10

It is needed to change live method to on method in all those events. I have made the change in all the methods, but I have only tested in the image uploader, because it is the one I am using in a project.

Hope it helps
